### PR TITLE
fix: correct azimuth to align other sensors

### DIFF
--- a/nebula_decoders/src/nebula_decoders_aeva/aeva_aeries2_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_aeva/aeva_aeries2_decoder.cpp
@@ -48,9 +48,9 @@ void AevaAeries2Decoder::processPointcloudMessage(const aeva::PointCloudMessage 
     point.distance = raw_point.range.value();
     // raw azimuth value from sensor:
     //  - normalized by 90deg
-    //  - apparently starts from +x axis and increases along with the counter clockwise
-    // point.asimuth:
-    //  - starts from +y axis and increases along with the clockwise
+    //  - apparently starts from +x axis and increases in counter clockwise direction
+    // point.azimuth:
+    //  - starts from +y axis and increases in clockwise direction
     point.azimuth = M_PI_2 - raw_point.azimuth.value() * M_PI_2;
     point.elevation = raw_point.elevation.value() * M_PI_4;
 

--- a/nebula_decoders/src/nebula_decoders_aeva/aeva_aeries2_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_aeva/aeva_aeries2_decoder.cpp
@@ -46,7 +46,12 @@ void AevaAeries2Decoder::processPointcloudMessage(const aeva::PointCloudMessage 
     AevaPoint point;
 
     point.distance = raw_point.range.value();
-    point.azimuth = -raw_point.azimuth.value() * M_PI_2;
+    // raw azimuth value from sensor:
+    //  - normalized by 90deg
+    //  - apparently starts from +x axis and increases along with the counter clockwise
+    // point.asimuth:
+    //  - starts from +y axis and increases along with the clockwise
+    point.azimuth = M_PI_2 - raw_point.azimuth.value() * M_PI_2;
     point.elevation = raw_point.elevation.value() * M_PI_4;
 
     ReturnType return_type = getReturnType(raw_point.peak_id);


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
N/A

## Description

<!-- Describe what this PR changes. -->
Compared with other sensors, the decoding result of Aeva Aeries2 seems not to be aligned with the coordinate system assumption. 
This PR modifies the azimuth angle calculation on decoding.

I checked the modification result by comparing the reference lidar (Seyond Falcon).

### setup
TF between two lidars are as follows ( `lidar_front`: Seyond Falcon (for reference), `lidar_front4d`: Aeva Aeries2. `lidar_front4d` was just translated to -y direction from `lidar_front`)
![Screenshot from 2025-02-19 23-50-42](https://github.com/user-attachments/assets/b2425d04-6760-4d9e-86a9-5e6c4dc586ef)


### before modification 
$` \mathrm{point.azimuth} = -\mathrm{raw\_point.azimuth.value()} * \frac{\pi}{2} `$

The white points were from the reference LiDAR, and the colored ones were from Aeva Aeries2.
![Screenshot from 2025-02-19 23-46-28](https://github.com/user-attachments/assets/7dfd12bd-55d6-48d8-b0d6-8b7e3356bfa5)

### after modification
$`\mathrm{point.azimuth} = \frac{\pi}{2} - \mathrm{raw\_point.azimuth.value()} * \frac{\pi}{2}`$

![Screenshot from 2025-02-19 23-48-11](https://github.com/user-attachments/assets/326f38f9-9a5c-4deb-96d6-dc48518b860c)


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
