### PR TITLE
feat: add option to use receive time as points timestamp

### DIFF
--- a/nebula_ros/include/nebula_ros/seyond/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/seyond/decoder_wrapper.hpp
@@ -55,6 +55,7 @@ private:
   rclcpp::Logger logger_;
 
   bool decode_{};
+  bool use_receive_timestamp_{};
 
   const std::shared_ptr<SeyondHwInterface> hw_interface_;
   std::shared_ptr<const SeyondSensorConfiguration> sensor_cfg_;

--- a/nebula_ros/src/seyond/decoder_wrapper.cpp
+++ b/nebula_ros/src/seyond/decoder_wrapper.cpp
@@ -54,6 +54,7 @@ SeyondDecoderWrapper::SeyondDecoderWrapper(
     rclcpp::QoS(rclcpp::QoSInitialization(qos_profile.history, 10), qos_profile);
 
   decode_ = decode_flag;
+  use_receive_timestamp_ = parent_node->declare_parameter<bool>("use_receive_time", false);
 
   nebula_points_pub_ = decode_flag ? parent_node->create_publisher<sensor_msgs::msg::PointCloud2>(
                                        "nebula_points", pointcloud_qos)
@@ -163,7 +164,12 @@ void SeyondDecoderWrapper::ProcessCloudPacket(
         auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(
                              std::chrono::duration<double>(std::get<1>(pointcloud_ts)))
                              .count();
-        ros_pc_msg_ptr->header.stamp = rclcpp::Time(nanoseconds);
+        if (use_receive_timestamp_) {
+          ros_pc_msg_ptr->header.stamp = packet_msg->stamp;
+        }
+        else{
+          ros_pc_msg_ptr->header.stamp = rclcpp::Time(nanoseconds);
+        }
         PublishCloud(std::move(ros_pc_msg_ptr), nebula_points_pub_);
       }
     }


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- New Feature


## Related Links
[TIER IV internal discussion](https://star4.slack.com/archives/C081UTGR5QF/p1744015298725919?thread_ts=1744012168.767099&cid=C081UTGR5QF)

## Description

This PR introduces a new parameter `use_receive_time` to `SeyondDecoderWrapper`.

- Adds `use_receive_timestamp_` member variable.
- Declares the parameter `use_receive_time` via `declare_parameter<bool>()`.
- Allows users to choose between using the receive timestamp (`packet_msg->stamp`) or the original timestamp (`pointcloud_ts`) for `ros_pc_msg_ptr->header.stamp`.

This makes the timestamping behavior of published point clouds more configurable, which is useful in synchronization-sensitive applications.

## Review Procedure

1. Launch a node by using drs_launch.
2. Pass `use_receive_time: true` or `use_receive_time: false`.
3. Confirm that when `use_receive_time: true`, the point cloud messages use `packet_msg->stamp` as `header.stamp`.
4. Confirm that when `use_receive_time: false`, the timestamp falls back to `pointcloud_ts`.

## Remarks

- Default behavior (`use_receive_time: false`) preserves existing timestamping.

## Pre-Review Checklist for the PR Author

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline  
- [ ] (Optional) Unit tests have been written for new behavior  
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
