### PR TITLE
Feat/flush buffered cloud points

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/decoders/seyond_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/decoders/seyond_decoder.hpp
@@ -142,6 +142,7 @@ private:
   double current_ts_start_ = 0.0;
   static constexpr double us_in_second_c = 1000000.0;
   static constexpr double ten_us_in_second_c = 100000.0;
+  static const size_t kPointCloudReserveSize = 2000000;
 
 public:
   /// @brief Constructor
@@ -157,7 +158,7 @@ public:
 
   int peek(const std::vector<uint8_t> & packet);
 
-  std::tuple<drivers::NebulaPointCloudPtr, double> getPointcloud() override;
+  std::tuple<drivers::NebulaPointCloudPtr, double> getPointcloud(bool flush = false) override;
 
   static double lookup_cos_table_in_unit(int i);
 

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/decoders/seyond_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/decoders/seyond_scan_decoder.hpp
@@ -39,7 +39,7 @@ public:
 
   /// @brief Returns the point cloud and timestamp of the last scan
   /// @return A tuple of point cloud and timestamp in nanoseconds
-  virtual std::tuple<drivers::NebulaPointCloudPtr, double> getPointcloud() = 0;
+  virtual std::tuple<drivers::NebulaPointCloudPtr, double> getPointcloud(bool flush = false) = 0;
 };
 }  // namespace drivers
 }  // namespace nebula

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/seyond_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/seyond_driver.hpp
@@ -72,6 +72,10 @@ public:
   /// @param nebula_packets Message
   /// @return Bool of whether the scan has been completed or not
   bool PeekCloudPacket(const std::vector<uint8_t> & packet);
+
+  /// @brief Flush the current point cloud
+  /// @return tuple of Point cloud and timestamp
+  std::tuple<drivers::NebulaPointCloudPtr, double> FlushCloudPoints();
 };
 
 }  // namespace drivers

--- a/nebula_decoders/src/nebula_decoders_seyond/seyond_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_seyond/seyond_driver.cpp
@@ -54,6 +54,11 @@ bool SeyondDriver::PeekCloudPacket(const std::vector<uint8_t> & packet)
   return scan_decoder_->hasScanned();
 }
 
+std::tuple<drivers::NebulaPointCloudPtr, double> SeyondDriver::FlushCloudPoints()
+{
+  return scan_decoder_->getPointcloud(true);
+}
+
 Status SeyondDriver::SetCalibrationConfiguration(
   const SeyondCalibrationConfiguration & /* calibration_configuration */)
 {


### PR DESCRIPTION
This pull request introduces updates to the Seyond point cloud decoder and driver to improve memory management and add the ability to flush the current point cloud explicitly. The most significant changes are the introduction of a configurable reserve size, an updated interface for retrieving point clouds with a flush option, and a new method in the driver for flushing cloud points.

### Point cloud memory management improvements
* Added a static constant `kPointCloudReserveSize` to `SeyondDecoder` and used it to reserve memory for point clouds, replacing hardcoded values for better maintainability. [[1]](diffhunk://#diff-e2c2cd54ca334c03919626faa0d9c4ff60e5eb5924d54a34d61da63e14c090c7R145) [[2]](diffhunk://#diff-23041fe8434b187daef9c60cfaf34ab591cce5581efcc1ac52c8e75b9544e8f6L54-R55)

### API and interface changes
* Updated the `getPointcloud` method in both `SeyondScanDecoder` (base class) and `SeyondDecoder` (derived class) to accept a `flush` parameter, allowing explicit control over when the point cloud data is returned and reset. [[1]](diffhunk://#diff-e2c2cd54ca334c03919626faa0d9c4ff60e5eb5924d54a34d61da63e14c090c7L160-R161) [[2]](diffhunk://#diff-6063c40e66a0a508d896e18aa5f91d8e3b4cfe1d6d9f3de1b95906447a8acf43L42-R42) [[3]](diffhunk://#diff-23041fe8434b187daef9c60cfaf34ab591cce5581efcc1ac52c8e75b9544e8f6L355-R364)
* Implemented logic in `SeyondDecoder::getPointcloud` to flush and reset the point cloud when requested, ensuring accurate data retrieval and efficient memory usage.

### Driver enhancements
* Added a new method `FlushCloudPoints` to `SeyondDriver` that utilizes the updated `getPointcloud` interface to flush the current point cloud and timestamp. [[1]](diffhunk://#diff-71d38fd189603bb13b4235158a3e854d12a739101f2b29f9a2d405f5adc1144aR75-R78) [[2]](diffhunk://#diff-f37d102430637fb9f68ad4ae50a1114495daad7dc37745b6a1066b7192563dceR57-R61)