### PR TITLE
fix(seyond): calculate point timestamp relative to scan start

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/decoders/seyond_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_seyond/decoders/seyond_decoder.hpp
@@ -140,6 +140,8 @@ private:
   static int8_t robin_nps_adjustment_[kRobinScanlines_][kHTableSize_][kXYZSize_];
   static int8_t nps_adjustment_[kVTableSize_][kHTableSize_][kSeyondChannelNumber][kXZSize_];
   double current_ts_start_ = 0.0;
+  double scan_start_us_ = 0.0;    // Scan start time in microseconds
+  double pkt_offset_us_ = 0.0;    // Packet offset from scan start in microseconds
   static constexpr double us_in_second_c = 1000000.0;
   static constexpr double ten_us_in_second_c = 100000.0;
   static const size_t kPointCloudReserveSize = 2000000;


### PR DESCRIPTION
## Summary

- Fix incorrect point `time_stamp` calculation in Seyond decoder
- Previously, timestamps only used packet-relative `ts_10us`, causing incorrect values when scans span multiple packets
- Now calculates timestamps relative to scan start time

## Changes

- Add `scan_start_us_` to track the first packet's timestamp in each scan
- Add `pkt_offset_us_` to calculate each packet's offset from scan start
- Update timestamp calculation: `(pkt_offset_us_ + ts_10us * 10) * 1000` [ns]

## Affected functions

- `unpack()`: Initialize/reset `scan_start_us_` at scan boundaries
- `data_packet_parse_()`: Calculate `pkt_offset_us_`
- `compact_data_packet_parse_()`: Calculate `pkt_offset_us_`
- `point_xyz_data_parse_()`: Use corrected timestamp formula

## Test plan

- [ ] Verify point timestamps are monotonically increasing within a scan
- [ ] Compare output with reference implementation (seyond_decoder in bag_converter)