### PR TITLE
fix(seyond): remove redundant AngleHV table prepend to NebulaPackets

### DIFF
--- a/nebula_ros/src/seyond/decoder_wrapper.cpp
+++ b/nebula_ros/src/seyond/decoder_wrapper.cpp
@@ -190,25 +190,6 @@ void SeyondDecoderWrapper::ProcessCloudPacket(
   if (publish_packets) {
     if (current_scan_msg_->packets.size() == 0) {
       current_scan_msg_->header.stamp = packet_msg->stamp;
-      // Add the calibration packet
-      if (calibration_cfg_ptr_) {
-        if (
-          (!calibration_cfg_ptr_->GetCalibrationString().empty()) &&
-          (sensor_cfg_->sensor_model == drivers::SensorModel::SEYOND_ROBIN_W)) {
-          const auto now = std::chrono::high_resolution_clock::now();
-          const auto timestamp_ns =
-            std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-          auto msg_ptr = std::make_unique<nebula_msgs::msg::NebulaPacket>();
-          msg_ptr->stamp.sec = static_cast<int>(timestamp_ns / 1'000'000'000);
-          msg_ptr->stamp.nanosec = static_cast<int>(timestamp_ns % 1'000'000'000);
-          std::string calibration_string = calibration_cfg_ptr_->GetCalibrationString();
-          std::vector<uint8_t> calibration_packet(
-            calibration_string.begin(), calibration_string.end());
-          msg_ptr->data.swap(calibration_packet);
-          current_scan_msg_->packets.emplace_back(*msg_ptr);
-        }
-      }
     }
     current_scan_msg_->packets.emplace_back(*packet_msg);
   }


### PR DESCRIPTION
## Summary
- Remove the logic that manually prepends the AngleHV calibration table packet to the start of each `NebulaPackets` scan for Robin W
- This is redundant because the LiDAR sends AngleHV table packets in the data stream, and the decoder already initializes `anglehv_table_` from these packets via `unpack()`
- The decoder also has a fallback path to load calibration from a file or HTTP download at construction time

## Test plan
- [ ] Verify Robin W live decoding works correctly (AngleHV table is initialized from packets or HTTP download)
- [ ] Verify Robin W rosbag replay works correctly (AngleHV table is initialized from recorded packets)